### PR TITLE
Add detection of subprocesses to LauncherAutoClose.ps1

### DIFF
--- a/LauncherAutoClose.ps1
+++ b/LauncherAutoClose.ps1
@@ -11,6 +11,11 @@ param (
     [Parameter(Mandatory=$true)][string]$game
 )
 
+
+# Kill launcher
+Write-Host 'Killing launcher'
+Get-Process $launcher | Stop-Process
+
 # Start Game
 Start-Process $launchcmd
 
@@ -30,6 +35,19 @@ Do {
 
 # Wait until game closes
 Wait-Process -InputObject $gameProcess
+
+# Get child processes of game
+$gameSubProcesses = Get-WmiObject win32_process | where {$_.ParentProcessId -eq $gameProcess.ID}
+
+# Wait until game child processes close
+Wait-Process -Id $gameSubProcesses.handle
+
+# Get child's child processes of game
+$gameSubProcessesSubProcesses = Get-WmiObject win32_process | where {$_.ParentProcessId -eq $gameProcesses.handle}
+
+# Wait until child's child processes close
+Wait-Process -Id $gameSubProcessesSubProcesses.handle
+
 Write-Host 'Game closed'
 
 # Wait for cloud saves or whatever


### PR DESCRIPTION
Certain titles have multiple layers of subprocesses whose parents close after launching them, let's check to make sure those have ended before killing the launcher.

Tested in:
Apex Legends
Battlefield 4
Titanfall 2

Todo: Loop through subprocesses until no more can be found, perhaps some games have more than two layers of subprocesses?