### PR TITLE
Add 30 minute timeout to LauncherAutoClose.ps1

### DIFF
--- a/LauncherAutoClose.ps1
+++ b/LauncherAutoClose.ps1
@@ -30,10 +30,19 @@ Start-Process $launchcmd
 $gameStarted = $false
 
 Write-Host 'Waiting for game to start'
+
+// Get current system date
+$currentDate = Get-Date
 Do {
     $gameProcess = Get-Process $game -ErrorAction SilentlyContinue
 
     If (!($gameProcess)) {
+        // Timeout after 30 minutes
+		If ($currentDate.AddMinutes(30) -gt (Get-Date))
+		{
+			Write-Host 'Game process could not be found'
+			exit
+		}
         Start-Sleep -Seconds 1
     } Else {
         Write-Host 'Game started!'

--- a/LauncherAutoClose.ps1
+++ b/LauncherAutoClose.ps1
@@ -31,14 +31,14 @@ $gameStarted = $false
 
 Write-Host 'Waiting for game to start'
 
-// Get current system date
+# Get current system date
 $currentDate = Get-Date
 Do {
     $gameProcess = Get-Process $game -ErrorAction SilentlyContinue
 
     If (!($gameProcess)) {
-        // Timeout after 30 minutes
-		If ($currentDate.AddMinutes(30) -gt (Get-Date))
+        # Timeout after 30 minutes
+		If ($currentDate.AddMinutes(30) -lt (Get-Date))
 		{
 			Write-Host 'Game process could not be found'
 			exit


### PR DESCRIPTION
In most cases this shouldn't trigger, but in case something goes wrong let's terminate the script if it can't find the game after 30 minutes.

30 minutes might be overkill, but let's overextend for people with slow computers or internet connections who might experience extended delays due to things such as required launcher or game updates