### PR TITLE
Implement basic Linux support

### DIFF
--- a/src/js/App.js
+++ b/src/js/App.js
@@ -13,10 +13,11 @@ import UWPNoise from '../img/uwp-noise.png';
 import Search from './Search.js';
 import Games from './games.js';
 import Import from './Import.js';
+import Remote from './Remote.js';
 
 // Using window.require so babel doesn't change the node require
 const electron = window.require('electron');
-const remote = electron.remote;
+const remote = new Remote(electron.remote);
 
 // Log renderer errors
 const log = window.require('electron-log');
@@ -75,8 +76,8 @@ class App extends React.Component {
     }
 
     render() {
-        const accentColor = remote.systemPreferences.getAccentColor();
         const navWidth = 48;
+        const accentColor = remote.systemPreferences.getAccentColor();
 
         const navigationTopNodes = [
             <SplitViewCommand key="0" label="Library" icon={'Library'} onClick={() => this.handleNavRedirect('/')} />,

--- a/src/js/Remote.js
+++ b/src/js/Remote.js
@@ -1,0 +1,28 @@
+export class Remote {
+    constructor(remote) {
+        this.remote = remote;
+        this.platform = process.platform;
+        this.systemPreferences = new SystemPreferences(this.remote);
+    }
+
+    getCurrentWindow() {
+        return this.remote.getCurrentWindow();
+    }
+}
+
+class SystemPreferences {
+    constructor(remote) {
+        this.remote = remote;
+    }
+
+    getAccentColor() {
+        if (process.platform === 'win32') {
+            return this.remote.getAccentColor();
+        } else {
+            // TODO: change this hard-coded colour
+            return '00FF00';
+        }
+    }
+}
+
+export default Remote;


### PR DESCRIPTION
This pull request adds **very basic** Linux support. Steam library shows up if Steam is installed in the default location ($HOME/.steam/steam/) and that's about it. It's able to find Steam libraries outside of the default location (found the one I have on my second hard drive mounted at /mnt/storage/), and you can scroll through the list. Finds both Linux native games and Windows ones (that run via Proton), and everything looks correct. Search also works. 

That aside however, importing games from other launchers is broken. A significant amount of work would probably be required to get this part to work (I did not attempt to implement it for the time being). Currently, opening the Import Games tab results in a JavaScript error and an infinite loading screen. Accent colour is also currently hard-coded on platforms that are not Windows. May continue to work on these things, may leave it for someone else. 

Regardless, these patches should not break Windows functionality whatsoever. 