### PR TITLE
Add proper exe name for Modern Warfare

### DIFF
--- a/src/js/importers/BattleNet.js
+++ b/src/js/importers/BattleNet.js
@@ -28,7 +28,7 @@ const BNET_GAMES = {
   odin: {
     name: 'Call of Duty: Modern Warfare',
     launchId: 'ODIN',
-    exes: ['codmw2019'],
+    exes: ['codmw2019', 'ModernWarfare'],
     icon: 'Modern Warfare Launcher.exe',
   },
   pro: {


### PR DESCRIPTION
Prior to this, the process wasn't properly tracked in: [LauncherAutoClose.ps1#L43](https://github.com/steamgriddb/steamgriddb-manager/blob/master/LauncherAutoClose.ps1#L43)

I'm not entirely sure where the exe name `codmw2019` was derived, so leaving it in for now