### PR TITLE
EGS Search patch

### DIFF
--- a/src/js/Search.jsx
+++ b/src/js/Search.jsx
@@ -44,7 +44,7 @@ class Search extends React.Component {
       id = game.appid;
     }
 
-    if (game.platform === 'other') {
+    if (game.platform === 'other' || game.platform === 'egs') {
       type = 'game';
       this.SGDB.searchGame(game.name)
         .then((gameResp) => {


### PR DESCRIPTION
Partially resolves #81, #78 

Due to inconsistencies with the EGS game manifests, most titles are unable to found within the API using the AppName identifier. This PR switches EGS to search by DisplayName instead which results in more accurate lookups.

Suggest changing EGS AppName to MandatoryAppFolderName provided the steamgriddb API is also updated to support all EGS games.

This does not resolve EGS imports, which still lookup using the AppName.

A more reliable solution to resolve any lookup issues could be to handle the API 404 Game Not Found response by initiating searchGame