### PR TITLE
Add BPM horizontal cover with old appid for non-Steam games

### DIFF
--- a/src/js/Search.jsx
+++ b/src/js/Search.jsx
@@ -66,6 +66,11 @@ class Search extends React.Component {
     this.setState({
       items: clonedItems,
     });
+    
+    //Add horizontalGrid BPM image for Non-Steam Games
+    if (game.appidold && location.state.assetType == 'horizontalGrid') {
+      Steam.addAsset(location.state.assetType, game.appidold, item.url);  
+    }
 
     Steam.addAsset(location.state.assetType, game.appid, item.url).then(() => {
       clonedItems[itemIndex].downloading = false;

--- a/src/js/Search.jsx
+++ b/src/js/Search.jsx
@@ -67,12 +67,16 @@ class Search extends React.Component {
       items: clonedItems,
     });
     
-    //Add horizontalGrid BPM image for Non-Steam Games
-    if (game.appidold && location.state.assetType == 'horizontalGrid') {
-      Steam.addAsset(location.state.assetType, game.appidold, item.url);  
-    }
+    const downloadPromises = [];
 
-    Steam.addAsset(location.state.assetType, game.appid, item.url).then(() => {
+    downloadPromises.push(Steam.addAsset(location.state.assetType, game.appid, item.url));
+    
+    // Add horizontalGrid BPM image for Non-Steam Games
+    if (game.appidold && location.state.assetType == 'horizontalGrid') {
+      downloadPromises.push(Steam.addAsset(location.state.assetType, game.appidold, item.url));
+    }
+    
+    Promise.all(downloadPromises).then(() => {
       clonedItems[itemIndex].downloading = false;
       this.setState({
         items: clonedItems,

--- a/src/js/Steam.js
+++ b/src/js/Steam.js
@@ -162,6 +162,7 @@ class Steam {
                     platform: storedGame.platform,
                     type: 'shortcut',
                     appid,
+                    appidold,
                   });
                   processed.push(configId);
                 }
@@ -176,6 +177,7 @@ class Steam {
                   platform: 'other',
                   type: 'shortcut',
                   appid,
+                  appidold,
                 });
               }
             });

--- a/src/js/Steam.js
+++ b/src/js/Steam.js
@@ -146,6 +146,7 @@ class Steam {
               const appName = item.appname || item.AppName || item.appName;
               const exe = item.exe || item.Exe;
               const appid = this.generateNewAppId(exe, appName);
+              const appidold = this.generateAppId(exe, appName);
               const configId = metrohash64(exe + item.LaunchOptions);
 
               if (store.has(`games.${configId}`)) {


### PR DESCRIPTION
As said in the [Issue 61](https://github.com/SteamGridDB/steamgriddb-manager/issues/61), BPM covers don't update with actual release.
@aranel616 fixed the issue with the [commit 6222596](https://github.com/SteamGridDB/steamgriddb-manager/commit/622259617da73d9ed00470dd52052ac22fd3c414#diff-1fd4a8d9ade4b277e0d49bed13f56cb41ed94fb63e411a0faa5a89ee8a1d276cR225) but fix it only on the import, not on updating covers.

I saw that @kongomongo fix it in [Pull 117](https://github.com/SteamGridDB/steamgriddb-manager/pull/117) for update covers.
But this code add an asset for every type of covers and for every game, even Steam games which result with _undefined_ files.
![image](https://user-images.githubusercontent.com/33598903/113591835-b095b880-9634-11eb-9a9e-19e0c5d5bc7f.png)

This commit fix it only for horizontalGrid and only for Non-Steam games (Steam game use usual ID for BPM pictures)
