### PR TITLE
Fix asset for manually added non-steam games

### DIFF
--- a/src/js/Steam.js
+++ b/src/js/Steam.js
@@ -145,8 +145,11 @@ class Steam {
             items.shortcuts.forEach((item) => {
               const appName = item.appname || item.AppName || item.appName;
               const exe = item.exe || item.Exe;
-              const appid = this.generateNewAppId(exe, appName);
               const configId = metrohash64(exe + item.LaunchOptions);
+              const appid = (item.appid) ?
+                (item.appid >>> 0) : //bitwise unsigned 32 bit ID of manually added non-steam game
+                this.generateNewAppId(exe, appName);
+              
 
               if (store.has(`games.${configId}`)) {
                 const storedGame = store.get(`games.${configId}`);


### PR DESCRIPTION
As I said here : https://github.com/SteamGridDB/steamgriddb-manager/issues/130, SteamGridDB don't update assets for non-steam games added manually (non imported by SteamGridDB).

After researches I found that Steam generate an random individual ID for every non-steam game manually added and it doesn't correspond to the function generateNewAppId used here,

It results that SteamGridDB update images with the wrong ID's

My commit set the value of appid with generateNewAppID only if there's no existing appid so it works with imported and manually added non-steam games.