### PR TITLE
Add support to new libraryfolders.vdf format

### DIFF
--- a/src/js/Steam.js
+++ b/src/js/Steam.js
@@ -79,18 +79,15 @@ class Steam {
       this.getSteamPath().then((steamPath) => {
         const parsedLibFolders = VDF.parse(fs.readFileSync(join(steamPath, 'steamapps', 'libraryfolders.vdf'), 'utf-8'));
         const games = [];
-        const libraries = [];
 
-        // Add Steam install dir
-        libraries.push(steamPath);
+        // Load extra library paths from libraryfolders.vdf
+        const extraLibraries = Object.entries(parsedLibFolders.LibraryFolders || parsedLibFolders.libraryfolders || {})
+          .filter(([key]) => !Number.isNaN(parseInt(key, 10)))
+          .filter(([_, library]) => typeof library === 'string' || library.mounted !== 0)
+          .map(([_, library]) => typeof library === 'string' ? library : library.path);
 
-        // Add library folders from libraryfolders.vdf
-        Object.keys(parsedLibFolders.LibraryFolders).forEach((key) => {
-          const library = parsedLibFolders.LibraryFolders[key];
-          if (!Number.isNaN(parseInt(key, 10))) {
-            libraries.push(library);
-          }
-        });
+        // Add Steam install dir and extra libraries
+        const libraries = [steamPath, ...extraLibraries]
 
         log.info(`Found ${libraries.length} Steam libraries`);
 


### PR DESCRIPTION
Add support to new libraryfolders.vdf format;
Fix infinite loading;
Issues:  #155  and #99 

Old format:
```vdf
"LibraryFolders"
{
   "1"        "D:\\SteamLibrary"
   "2"        "E:\\SteamLibrary"
}
```

New format:
```vdf
"libraryfolders"
{
    "1"
    {
        "path"        "D:\\SteamLibrary"
        "label"        ""
        "mounted"        "1"
        "contentid"        "xxxxxxxxx"
    }
    "2"
    {
        "path"        "E:\\SteamLibrary"
        "label"        ""
        "mounted"        "1"
        "contentid"        "xxxxxxxxx"
    }
}
```